### PR TITLE
Fix getAllSelfTickets code ambiguity & frontend compilation error

### DIFF
--- a/guides/05_updating_your_back-end.md
+++ b/guides/05_updating_your_back-end.md
@@ -40,23 +40,15 @@ Let's now add up a new API to our server: you want to show your end users only t
 
 ```Java
 @GetMapping("/tickets/self")
-public ResponseEntity<List<Ticket>> getAllSelfTickets(
-    Pageable pageable,
-    @RequestParam(required = false, defaultValue = "false") boolean eagerload
-) {
-    log.debug("REST request to get a page of user's Tickets");
-    Page<Ticket> page;
-    if (eagerload) {
-    page = ticketRepository.findAllWithEagerRelationships(pageable);
-    } else {
-    page = new PageImpl<>(ticketRepository.findByAssignedToIsCurrentUser());
-    }
+public ResponseEntity<List<Ticket>> getAllSelfTickets() {
+    log.debug("REST request to get all user's Tickets");
+    Page<Ticket> page = new PageImpl<>(ticketRepository.findByAssignedToIsCurrentUser());
     HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
     return ResponseEntity.ok().headers(headers).body(page.getContent());
 }
 ```
 
-If you check the file <walkthrough-editor-open-file filePath="BugTrackerJHipster/src/main/java/com/mycompany/bugtracker/repository/TicketRepository.java" text="TicketRepository.java"></walkthrough-editor-open-file>, you will see that the method has been already implemented, that is why this time you don't need to modify anything.
+If you check the file <walkthrough-editor-open-file filePath="BugTrackerJHipster/src/main/java/com/mycompany/bugtracker/repository/TicketRepository.java" text="TicketRepository.java"></walkthrough-editor-open-file>, you will see that the method `findByAssignedToIsCurrentUser` has been already implemented, that is why this time you don't need to modify anything.
 
 With the previous code added, we've supplemented our API with a new mapping: to see if the endpoint works as intended, start up your application and log in as an admin.
 

--- a/guides/06_editing_front.md
+++ b/guides/06_editing_front.md
@@ -158,9 +158,9 @@ import { Component, OnInit } from '@angular/core';
 import { ITicket } from 'app/shared/model/ticket.model';
 import { Account } from 'app/core/user/account.model';
 import { Subscription } from 'rxjs';
-import { TicketService } from 'app/entities/ticket';
+import { TicketService } from 'app/entities/ticket/ticket.service';
 import { JhiAlertService, JhiEventManager, JhiParseLinks } from 'ng-jhipster';
-import { AccountService } from 'app/core';
+import { AccountService } from 'app/core/auth/account.service';
 import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 
 @Component({
@@ -188,9 +188,9 @@ export class MyticketsComponent implements OnInit {
 
     ngOnInit() {
         this.loadSelf();
-        this.accountService.identity().then((account: Account) => {
+         this.accountService.identity().subscribe((account: Account) => {
             this.account = account;
-        });
+          });
         this.registerChangeInTickets();
     }
 


### PR DESCRIPTION
The current code in the guide is misleading by having a Pageable (unused),and a paramater "eagerload", which breaks getAllSelfTickets contract. If "eagerload" is set to true, the method won't respect its contract, which is to give the user's assigned tickets, and will instead give all existing tickets.

Since I can't find a simple clear way to make the user's assigned tickets pageable (without modifying TicketRepository), I just removed most of the code, but kept the Pagination header, to keep the same response format as before.