### PR TITLE
Update cloushell path and code to add

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All you need is a Google account and access to https://console.cloud.google.com 
 
 Click the button to run the tutorial:
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/seraphinandrieux/jhipster-guides&tutorial=guides/00_setting_up_your_environment.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/jhipster/jhipster-guides&tutorial=guides/00_setting_up_your_environment.md)
 
 **Please note that clicking this button will open the Google Cloud Shell in a new tab, clone the repository tutorials and start the tutorial.**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All you need is a Google account and access to https://console.cloud.google.com 
 
 Click the button to run the tutorial:
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/jhipster/jhipster-guides&tutorial=guides/00_setting_up_your_environment.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/seraphinandrieux/jhipster-guides&tutorial=guides/00_setting_up_your_environment.md)
 
 **Please note that clicking this button will open the Google Cloud Shell in a new tab, clone the repository tutorials and start the tutorial.**
 

--- a/guides/00_setting_up_your_environment.md
+++ b/guides/00_setting_up_your_environment.md
@@ -64,5 +64,5 @@ Congratulations! You are now ready to create an application.
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/01_creating_your_application.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/01_creating_your_application.md;
 ```

--- a/guides/01_creating_your_application.md
+++ b/guides/01_creating_your_application.md
@@ -220,5 +220,5 @@ If you've not yet added a repository on your github, we highly recommend you to 
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/02_continuous_integration.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/02_continuous_integration.md;
 ```

--- a/guides/02_continuous_integration.md
+++ b/guides/02_continuous_integration.md
@@ -100,5 +100,5 @@ Congratulations! You just set up the continuous integration for your project.
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/03_jhipster_app.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/03_jhipster_app.md;
 ```

--- a/guides/03_jhipster_app.md
+++ b/guides/03_jhipster_app.md
@@ -92,5 +92,5 @@ Congratulations!
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/04_creating_entities_with_jdl_studio.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/04_creating_entities_with_jdl_studio.md;
 ```

--- a/guides/04_creating_entities_with_jdl_studio.md
+++ b/guides/04_creating_entities_with_jdl_studio.md
@@ -197,7 +197,7 @@ After creating the .jh file, you can now generate entities from the JDL file usi
 Go to your project directory and type:
 
 ```bash
-jhipster import-jdl ~/jhipster-guides/res/jhipster-jdl.jh
+jhipster import-jdl ~/cloudshell_open/jhipster-guides/res/jhipster-jdl.jh
 ```
 
 Run the generated test suite, with 

--- a/guides/04_creating_entities_with_jdl_studio.md
+++ b/guides/04_creating_entities_with_jdl_studio.md
@@ -215,5 +215,5 @@ Congratulations! You now know how to create entities !
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/05_updating_your_back-end.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/05_updating_your_back-end.md;
 ```

--- a/guides/05_updating_your_back-end.md
+++ b/guides/05_updating_your_back-end.md
@@ -98,5 +98,5 @@ Congratulations ! You managed to create a new mapping for your server and improv
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/06_editing_front.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/06_editing_front.md;
 ```

--- a/guides/05_updating_your_back-end.md
+++ b/guides/05_updating_your_back-end.md
@@ -18,18 +18,18 @@ Now, head to the file <walkthrough-editor-open-file filePath="BugTrackerJHipster
 
 ```Java
 @GetMapping("/tickets")
-public ResponseEntity<List<Ticket>> getAllTickets(Pageable pageable, @RequestParam MultiValueMap<String, String> queryParams, UriComponentsBuilder uriBuilder, @RequestParam(required = false, defaultValue = "false") boolean eagerload) {
-    log.debug("REST request to get a page of Tickets");
-    Page<Ticket> page;
-    if (eagerload) {
-        page = ticketRepository.findAllWithEagerRelationships(pageable);
-    } else {
-        //page = ticketRepository.findAll(pageable);
-        page = ticketRepository.findAllByOrderByDueDateAsc(pageable);
+    public ResponseEntity<List<Ticket>> getAllTickets(Pageable pageable, @RequestParam(required = false, defaultValue = "false") boolean eagerload) {
+        log.debug("REST request to get a page of Tickets");
+        Page<Ticket> page;
+        if (eagerload) {
+            page = ticketRepository.findAllWithEagerRelationships(pageable);
+        } else {
+            //page = ticketRepository.findAll(pageable);
+            page = ticketRepository.findAllByOrderByDueDateAsc(pageable);
+        }
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
+        return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(uriBuilder.queryParams(queryParams), page);
-    return ResponseEntity.ok().headers(headers).body(page.getContent());
-}
 ```
 
 If you start your server again, you should see that the tickets are automatically ordered by the due date.
@@ -54,6 +54,12 @@ public ResponseEntity<List<Ticket>> getAllSelfTickets(
     HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
     return ResponseEntity.ok().headers(headers).body(page.getContent());
 }
+```
+
+Don't forget to add the import:
+
+```Java
+import org.springframework.data.domain.PageImpl;
 ```
 
 If you check the file <walkthrough-editor-open-file filePath="BugTrackerJHipster/src/main/java/com/mycompany/bugtracker/repository/TicketRepository.java" text="TicketRepository.java"></walkthrough-editor-open-file>, you will see that the method has been already implemented, that is why this time you don't need to modify anything.

--- a/guides/06_editing_front.md
+++ b/guides/06_editing_front.md
@@ -187,8 +187,8 @@ export class MyticketsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadSelf();
-    this.accountService.identity().subscribe((account)  => {
-      this.account= account ;
+    this.accountService.identity().subscribe((account) => {
+      this.account = account;
     });
     this.registerChangeInTickets();
   }

--- a/guides/06_editing_front.md
+++ b/guides/06_editing_front.md
@@ -316,5 +316,5 @@ Congratulations! You now know how to edit your front !
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/07_testing_your_application.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/07_testing_your_application.md;
 ```

--- a/guides/06_editing_front.md
+++ b/guides/06_editing_front.md
@@ -158,72 +158,74 @@ import { Component, OnInit } from '@angular/core';
 import { ITicket } from 'app/shared/model/ticket.model';
 import { Account } from 'app/core/user/account.model';
 import { Subscription } from 'rxjs';
-import { TicketService } from 'app/entities/ticket';
+import { TicketService } from 'app/entities/ticket/ticket.service';
 import { JhiAlertService, JhiEventManager, JhiParseLinks } from 'ng-jhipster';
-import { AccountService } from 'app/core';
+import { AccountService } from 'app/core/auth/account.service';
 import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 
 @Component({
-    selector: 'jhi-mytickets',
-    templateUrl: './mytickets.component.html',
-    styles: []
+  selector: 'jhi-mytickets',
+  templateUrl: './mytickets.component.html',
+  styles: []
 })
 export class MyticketsComponent implements OnInit {
-    tickets: ITicket[];
+  tickets?: ITicket[];
+  account?: Account | null;
+  eventSubscriber?: Subscription;
+  predicate: any;
+  reverse: any;
+  links: any;
+  totalItems: any;
 
-    account: Account;
-    eventSubscriber: Subscription;
-    predicate: any;
-    reverse: any;
-    links: any;
-    totalItems: any;
+  constructor(
+    private accountService: AccountService,
+    private ticketService: TicketService,
+    private jhiAlertService: JhiAlertService,
+    private eventManager: JhiEventManager,
+    private parseLinks: JhiParseLinks
+  ) {}
 
-    constructor(
-        private accountService: AccountService,
-        private ticketService: TicketService,
-        private jhiAlertService: JhiAlertService,
-        private eventManager: JhiEventManager,
-        private parseLinks: JhiParseLinks
-    ) {}
+  ngOnInit(): void {
+    this.loadSelf();
+    this.accountService.identity().subscribe((account)  => {
+      this.account= account ;
+    });
+    this.registerChangeInTickets();
+  }
 
-    ngOnInit() {
-        this.loadSelf();
-        this.accountService.identity().then((account: Account) => {
-            this.account = account;
-        });
-        this.registerChangeInTickets();
+  loadSelf(): void {
+    this.ticketService
+      .queryMyTickets()
+      .subscribe(
+        (res: HttpResponse<ITicket[]>) => this.paginateTickets(res.body ? res.body : [], res.headers),
+        (res: HttpErrorResponse) => this.onError(res.message)
+      );
+  }
+
+  sort(): string[] {
+    const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+    if (this.predicate !== 'id') {
+      result.push('id');
     }
+    return result;
+  }
 
-    loadSelf() {
-        this.ticketService
-            .queryMyTickets()
-            .subscribe(
-                (res: HttpResponse<ITicket[]>) => this.paginateTickets(res.body, res.headers),
-                (res: HttpErrorResponse) => this.onError(res.message)
-            );
-    }
+  protected paginateTickets(data: ITicket[], headers: HttpHeaders): void {
+    //alert(headers.get('link'));
+    this.links = this.parseLinks.parse(headers.get('link') || '');
+    //alert('coucou');
+    this.totalItems = parseInt(headers.get('X-Total-Count') ? this.totalItems : '', 10);
+    this.tickets = data;
 
-    sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
-        if (this.predicate !== 'id') {
-            result.push('id');
-        }
-        return result;
-    }
+  }
 
-    protected paginateTickets(data: ITicket[], headers: HttpHeaders) {
-        this.links = this.parseLinks.parse(headers.get('link'));
-        this.totalItems = parseInt(headers.get('X-Total-Count'), 10);
-        this.tickets = data;
-    }
+  protected onError(errorMessage: string): void {
+    this.jhiAlertService.error(errorMessage, null, '');
+  }
 
-    protected onError(errorMessage: string) {
-        this.jhiAlertService.error(errorMessage, null, null);
-    }
-
-    registerChangeInTickets() {
-        this.eventSubscriber = this.eventManager.subscribe('ticketListModification', response => this.loadSelf());
-    }
+  registerChangeInTickets(): void {
+    this.eventSubscriber = this.eventManager.subscribe('ticketListModification', (response : any) => this.loadSelf());
+  }
 }
 
 ```
@@ -266,31 +268,42 @@ import { MyticketsComponent } from 'app/mytickets/mytickets.component';
 The file should look like this:
 ```typescript
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { errorRoute, navbarRoute } from './layouts';
+import { RouterModule } from '@angular/router';
+import { errorRoute } from './layouts/error/error.route';
+import { navbarRoute } from './layouts/navbar/navbar.route';
 import { DEBUG_INFO_ENABLED } from 'app/app.constants';
 import { MyticketsComponent } from 'app/mytickets/mytickets.component';
+
+import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 
 const LAYOUT_ROUTES = [navbarRoute, ...errorRoute];
 
 @NgModule({
-    imports: [
-        RouterModule.forRoot(
-            [
-                {
-                    path: 'jhi-mytickets',
-                    component: MyticketsComponent
-                },
-                {
-                    path: 'admin',
-                    loadChildren: './admin/admin.module#BugTrackerJHipsterAdminModule'
-                },
-                ...LAYOUT_ROUTES
-            ],
-            { useHash: true, enableTracing: DEBUG_INFO_ENABLED }
-        )
-    ],
-    exports: [RouterModule]
+  imports: [
+    RouterModule.forRoot(
+      [
+        {
+          path: 'jhi-mytickets',
+          component: MyticketsComponent
+        },
+        {
+          path: 'admin',
+          data: {
+            authorities: ['ROLE_ADMIN']
+          },
+          canActivate: [UserRouteAccessService],
+          loadChildren: () => import('./admin/admin-routing.module').then(m => m.AdminRoutingModule)
+        },
+        {
+          path: 'account',
+          loadChildren: () => import('./account/account.module').then(m => m.AccountModule)
+        },
+        ...LAYOUT_ROUTES
+      ],
+      { enableTracing: DEBUG_INFO_ENABLED }
+    )
+  ],
+  exports: [RouterModule]
 })
 export class BugTrackerJHipsterAppRoutingModule {}
 ```

--- a/guides/07_testing_your_application.md
+++ b/guides/07_testing_your_application.md
@@ -130,5 +130,5 @@ Congratulations! You now know how to test your application !
 Enter the next command line to start the next tutorial:
 
 ```bash
-cloudshell launch-tutorial -d ~/jhipster-guides/guides/08_deploying_your_app.md;
+cloudshell launch-tutorial -d ~/cloudshell_open/jhipster-guides/guides/08_deploying_your_app.md;
 ```

--- a/guides/07_testing_your_application.md
+++ b/guides/07_testing_your_application.md
@@ -59,8 +59,6 @@ Performance tests are done with [Gatling](http://gatling.io/), and are located i
 
 To run Gatling tests, you must first install Gatling: please go to the [Gatling download page](https://gatling.io/download/) and follow the instructions there. Please note we do not allow to run Gatling from Maven or Gradle, as it causes some classpath issues with other plugins (mainly because of the use of Scala).
 
-**NOTE** We currently support Gatling 2.x only. You can download the latest 2.x version directly from [maven central](https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/2.3.1/gatling-charts-highcharts-bundle-2.3.1-bundle.zip).
-
 **Warning!** At the moment, those tests do not take into account the validation rules you may have enforced on your entities. Also tests for creating entities that have a required relationship with another entity will fail out of the box. You will anyway need to change those tests, according to your business rules, so here are few tips to improve your tests:
 
 *   On your running application, go to the `Administration > Logs` screen, and put `org.springframework` in `debug` mode. You will see the validation errors, for example.

--- a/guides/07_testing_your_application.md
+++ b/guides/07_testing_your_application.md
@@ -76,7 +76,7 @@ For running Gatling tests on a microservice application, you have to:
 In this tutorial, we've given you an installation script for Gatling.
 Run the following command to install it:
 ```bash
-~/jhipster-guides/utils/install-gatling.sh
+~/cloudshell_open/jhipster-guides/utils/install-gatling.sh
 ```
 
 To run the Gatling test, head to:
@@ -88,7 +88,7 @@ cd ~/BugTrackerJHipster/src/test/gatling
 and run:
 
 ```bash
-~/jhipster-guides/gatling/bin/gatling.sh
+~/cloudshell_open/jhipster-guides/gatling/bin/gatling.sh
 ```
 
 Let's stress test our Project API, so choose **1**. You don't especially need to give a simulation id nor a description so you can just skip these parts.

--- a/utils/install-gatling.sh
+++ b/utils/install-gatling.sh
@@ -2,4 +2,4 @@
 
 curl -sS https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/2.3.1/gatling-charts-highcharts-bundle-2.3.1-bundle.zip > gatling.zip
 unzip gatling && rm gatling.zip
-mv gatling-charts-highcharts-bundle-2.3.1 ~/jhipster-guides/gatling
+mv gatling-charts-highcharts-bundle-2.3.1 ~/cloudshell_open/jhipster-guides/gatling


### PR DESCRIPTION
I updated all paths which are used inside the tuto to integrate easily the "copy to shell" and don't have to add `/cloudshell_open`  manually.
Besides, since the tuto's creation, some objects were modified and the current code to add is obsolete.
I removed the obsolete warning about gatling version.